### PR TITLE
fix: match test alias path to directory

### DIFF
--- a/modules/saku-policy-store/deps.edn
+++ b/modules/saku-policy-store/deps.edn
@@ -48,7 +48,7 @@
                         :main-class saku.main
                         :jar "target/saku-policy-store.jar"}}
 
-  :test {:extra-paths ["test"]
+  :test {:extra-paths ["tests"]
          :extra-deps
          {lambdaisland/kaocha                           {:mvn/version "1.60.977"}
           integrant/repl                                {:mvn/version "0.3.2"}}


### PR DESCRIPTION
Alternatively, we could perhaps evaluate following the more common convention of naming the test directory just `test` versus `tests`. 