### PR TITLE
Explicit logging deps

### DIFF
--- a/modules/saku-policy-store/deps.edn
+++ b/modules/saku-policy-store/deps.edn
@@ -22,7 +22,9 @@
         borkdude/edamame                                {:mvn/version "0.0.19"}
         luchiniatwork/ambiente                          {:mvn/version "0.1.4"}
         net.clojars.luchiniatwork/anomalies             {:mvn/version "0.0.2"}
-        luchiniatwork/orzo                              {:mvn/version "23.2.5"}}
+        luchiniatwork/orzo                              {:mvn/version "23.2.5"}
+        com.taoensso/timbre                             {:mvn/version "6.1.0"}
+        com.fzakaria/slf4j-timbre                       {:mvn/version "0.3.21"}}
 
  :aliases
  {:dev {:extra-paths ["dev"]

--- a/modules/saku-policy-store/deps.edn
+++ b/modules/saku-policy-store/deps.edn
@@ -42,7 +42,8 @@
             {}}
 
   :uberjar {:extra-deps
-            {com.github.seancorfield/depstar            {:mvn/version "2.1.303"}}
+            {com.github.seancorfield/depstar            {:mvn/version "2.1.303"
+																												 :exclusions [org.slf4j/slf4j-nop]}}
             :exec-fn hf.depstar/uberjar
             :exec-args {:aot true
                         :main-class saku.main


### PR DESCRIPTION
Right now saku-policy-store is depending on timbre being available implicitly, provided by _some_ dependent library. We should depend directly on all libraries used. I also added slf4j-timbre to forward slf4j logs to timbre. 

This will also remove the following message when starting saku. 
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```