### PR TITLE
chore: build uberjar with tools.build

### DIFF
--- a/modules/saku-policy-store/Dockerfile
+++ b/modules/saku-policy-store/Dockerfile
@@ -22,7 +22,7 @@ COPY . ./
 
 # RUN clojure -M:gen-sdl > resources/graphql.sdl
 
-RUN clojure -X:uberjar
+RUN clojure -T:build uber
 
 ##################################################
 ## Server Proper

--- a/modules/saku-policy-store/build.clj
+++ b/modules/saku-policy-store/build.clj
@@ -1,0 +1,21 @@
+(ns build
+  (:require [clojure.tools.build.api :as b]))
+
+(def class-dir "target/classes")
+(def basis (b/create-basis {:project "deps.edn"}))
+(def uber-file "target/saku-policy-store.jar")
+
+(defn clean [_]
+  (b/delete {:path "target"}))
+
+(defn uber [_]
+  (clean nil)
+  (b/copy-dir {:src-dirs   ["src" "resources"]
+               :target-dir class-dir})
+  (b/compile-clj {:basis     basis
+                  :src-dirs  ["src"]
+                  :class-dir class-dir})
+  (b/uber {:class-dir class-dir
+           :uber-file uber-file
+           :basis     basis
+           :main      'my.lib.main}))

--- a/modules/saku-policy-store/deps.edn
+++ b/modules/saku-policy-store/deps.edn
@@ -31,6 +31,9 @@
         :extra-deps
         {integrant/repl                                 {:mvn/version "0.3.2"}}}
 
+	:build {:deps {io.github.clojure/tools.build {:mvn/version "0.9.4"}}
+					:ns-default build}
+
   :run {:exec-fn system-utils.initializer/start-system
         :jvm-opts ["--add-opens=java.base/java.nio=ALL-UNNAMED"
                    "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED"]}
@@ -42,14 +45,6 @@
   :scripts {:extra-paths ["scripts"]
             :extra-deps
             {}}
-
-  :uberjar {:extra-deps
-            {com.github.seancorfield/depstar            {:mvn/version "2.1.303"
-																												 :exclusions [org.slf4j/slf4j-nop]}}
-            :exec-fn hf.depstar/uberjar
-            :exec-args {:aot true
-                        :main-class saku.main
-                        :jar "target/saku-policy-store.jar"}}
 
   :test {:extra-paths ["tests"]
          :extra-deps

--- a/modules/saku-policy-store/package.json
+++ b/modules/saku-policy-store/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "clojure -X:uberjar",
+    "build": "clojure -T:build uber",
     "test": "clojure -X:test",
     "bump": "clojure -M:scripts -m bump-version",
     "deploy": "clojure -M:scripts -m docker-build && clojure -M:scripts -m docker-push"


### PR DESCRIPTION
depstar is [deprecated now](https://github.com/seancorfield/depstar#use-toolsbuild). The preferred uberjar building mechanism is now with tools.build. Fortunately, the switch is easy.  