### PR TITLE
chore: update to lacinia 1.2.1

### DIFF
--- a/modules/saku-policy-store/deps.edn
+++ b/modules/saku-policy-store/deps.edn
@@ -10,7 +10,7 @@
         ;; System components
         net.clojars.luchiniatwork/system-datahike       {:mvn/version "0.0.7"}
         net.clojars.luchiniatwork/system-utils          {:mvn/version "0.0.6"}
-        net.clojars.luchiniatwork/system-lacinia        {:mvn/version "0.0.3"}
+        net.clojars.luchiniatwork/system-lacinia        {:mvn/version "0.0.4"}
 
         ;; Saku Core
         net.clojars.luchiniatwork/saku-core             {:mvn/version "23.1.2"}

--- a/modules/saku-policy-store/deps.edn
+++ b/modules/saku-policy-store/deps.edn
@@ -16,6 +16,7 @@
         net.clojars.luchiniatwork/saku-core             {:mvn/version "23.1.2"}
 
         ;; Utilities
+        com.walmartlabs/lacinia 												{:mvn/version "1.2.1"}
         metosin/jsonista                                {:mvn/version "0.3.5"}
         metosin/malli                                   {:mvn/version "0.10.1"}
         camel-snake-kebab/camel-snake-kebab             {:mvn/version "0.4.2"}


### PR DESCRIPTION
Currently we're relying on the implicit lacinia dependency brought in by system-lacinia. Since the policy store explicitly depends on lacinia being available, we should add it to our dependencies.

Additionally, updating to 1.2.1 will remove the following warnings from the log when launching the policy store. 

```
WARNING: parse-boolean already refers to: #'clojure.core/parse-boolean in namespace: com.walmartlabs.lacinia.schema, being replaced by: #'com.walmartlabs.lacinia.schema/parse-boolean
WARNING: parse-uuid already refers to: #'clojure.core/parse-uuid in namespace: system-lacinia.resolvers-util, being replaced by: #'system-lacinia.resolvers-util/parse-uuid
```