### PR TITLE
Support wildcard matching with regex special characters

### DIFF
--- a/modules/saku-core/src/saku/utils.cljc
+++ b/modules/saku-core/src/saku/utils.cljc
@@ -3,20 +3,18 @@
 
 (defn ^:private regex-star [text]
   (re-pattern (str "(?i)^" (-> text
-                               (s/replace #"\." "\\.")
-                               (s/replace #"\*" ".*")))))
+                             (s/replace #"(\\|\.|\+|\?|\^|\$|\(|\)|\[|\]|\{|\}|\|)" (fn [[_ c]] (str "\\" c)))
+                             (s/replace #"\*" ".*")))))
 
 (defn star-match [^String a ^String b]
   (when (and (string? a) (string? b))
     (boolean (or (re-matches (regex-star a) b)
-                 (re-matches (regex-star b) a)))))
+               (re-matches (regex-star b) a)))))
 
-(defn star-match-one-to-many [a coll]
-  (some #(star-match a %) coll))
 
 (defn star-match-many-to-many [coll-a coll-b]
   (some #(some (partial star-match %) coll-a)
-        coll-b))
+    coll-b))
 
 (defn star-match-target [^String star ^String target]
   (boolean (re-matches (regex-star star) target)))
@@ -26,4 +24,4 @@
 
 (defn star-match-target-many-to-many [coll-a coll-b]
   (some #(some (partial star-match-target %) coll-a)
-        coll-b))
+    coll-b))

--- a/modules/saku-core/tests/saku/utils_test.cljc
+++ b/modules/saku-core/tests/saku/utils_test.cljc
@@ -1,0 +1,16 @@
+(ns saku.utils-test
+  (:require
+    [clojure.test :refer [deftest is]]
+    [saku.utils :as utils]))
+
+(deftest star-match-test
+  (is (= true (utils/star-match "a" "a"))
+    "exact match")
+  (is (= false (utils/star-match "a" "b"))
+    "exact non-match")
+  (is (= true (utils/star-match "a*" "ab"))
+    "wildcard match")
+  (is (= false (utils/star-match "a*" "bac"))
+    "wildcard miss")
+  (is (= true (utils/star-match "a:*b|c|d:*" "a:b|c|d:1"))
+    "wildcard with regex special character"))


### PR DESCRIPTION
## Problem

Using regex special characters in a match pattern results in unintended behavior because the special character is interpreted as a special character instead of the character literal.

## Solution

Escape regex special characters.

## Examples

### Expected 

```clojure
(star-match "drn:org|a:*" "drn:org|a:resource")
=> true
```

### Actual 

```clojure
(star-match "drn:org|a:*" "drn:org|a:resource")
=> false
```